### PR TITLE
The candidate's Log in went to the back office, and his page had three navies

### DIFF
--- a/src/app/for-candidates/page.tsx
+++ b/src/app/for-candidates/page.tsx
@@ -197,7 +197,7 @@ export default function ForCandidatesPage() {
         </div>
       </section>
 
-      <section className="border-t border-[rgba(13,27,42,0.08)] bg-[#eef1f5] py-14 md:py-20 lg:py-24">
+      <section className="border-t border-[rgba(13,27,42,0.08)] bg-surface py-14 md:py-20 lg:py-24">
         <div className="mx-auto w-full max-w-content px-6 md:px-12 lg:px-20">
           <ScrollReveal variant="fadeUp" className="text-center">
             <h2 className="am-h2 font-display font-extrabold tracking-[-0.02em] text-[#0D1B2A]">Industries we cover</h2>
@@ -253,7 +253,7 @@ export default function ForCandidatesPage() {
         </div>
       </section>
 
-      <section className="border-t border-[rgba(201,168,76,0.08)] bg-[#0a121c] py-14 md:py-20 lg:py-24">
+      <section className="border-t border-[rgba(201,168,76,0.08)] bg-navy py-14 md:py-20 lg:py-24">
         <div className="mx-auto w-full max-w-content px-6 md:px-12 lg:px-20">
           <ScrollReveal variant="fadeUp" className="text-center">
             <h2 className="am-h2 font-display font-extrabold text-white">What we offer</h2>
@@ -264,7 +264,7 @@ export default function ForCandidatesPage() {
           <div className="mt-12 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 lg:gap-6">
             {OFFER_CARDS.map((card) => (
               <ScrollReveal key={card.title} variant="fadeUp">
-                <article className="flex h-full flex-col rounded-2xl border border-[rgba(201,168,76,0.18)] bg-[#0D1B2A] p-6 md:p-7">
+                <article className="flex h-full flex-col rounded-2xl border border-[rgba(201,168,76,0.18)] bg-white/[0.04] p-6 md:p-7">
                   <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-[rgba(201,168,76,0.25)] bg-[rgba(201,168,76,0.06)]">
                     <ShieldCheck className="text-[#C9A84C]" size={20} strokeWidth={1.75} aria-hidden />
                   </div>

--- a/src/components/candidates/CandidateAccountSection.tsx
+++ b/src/components/candidates/CandidateAccountSection.tsx
@@ -5,12 +5,12 @@ const goldBtn =
 
 export default function CandidateAccountSection() {
   return (
-    <section className="border-b border-[rgba(201,168,76,0.14)] bg-[#0a121c] py-12 md:py-16 lg:py-20">
+    <section className="border-b border-[rgba(201,168,76,0.14)] bg-navy py-12 md:py-16 lg:py-20">
       <div className="mx-auto w-full max-w-content px-6 md:px-12 lg:px-20">
         <div className="mx-auto max-w-3xl space-y-10 md:space-y-12">
           <div
             id="register"
-            className="scroll-mt-[100px] rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[#0D1B2A] p-6 md:p-8"
+            className="scroll-mt-[100px] rounded-2xl border border-white/[0.1] bg-white/[0.04] p-6 md:p-8"
           >
             <h2 className="font-display text-2xl font-bold tracking-tight text-white md:text-[28px]">
               New here? Join our candidate network
@@ -29,7 +29,7 @@ export default function CandidateAccountSection() {
             </div>
           </div>
 
-          <div className="rounded-2xl border border-[rgba(201,168,76,0.35)] bg-[#0D1B2A] p-6 shadow-[0_12px_40px_rgba(0,0,0,0.25)] md:p-8">
+          <div className="rounded-2xl border border-[rgba(201,168,76,0.35)] bg-white/[0.04] p-6 md:p-8">
             <h2 className="font-display text-2xl font-bold tracking-tight text-white md:text-[28px]">Already registered?</h2>
             <p className="mt-3 text-sm leading-relaxed text-white/70 md:text-base">
               Access your profile and track your applications.

--- a/src/components/home/Forsiden.tsx
+++ b/src/components/home/Forsiden.tsx
@@ -6,6 +6,7 @@ import { IndustryStrip } from "@/components/home/IndustryStrip";
 import { JobSearchBar } from "@/components/home/JobSearchBar";
 import { ForsidenFaq, ForsidenFaqJsonLd } from "@/components/seo/ForsidenFaqJsonLd";
 import { JobPostingJsonLd, OrganizationJsonLd } from "@/components/seo/JobPostingJsonLd";
+import { CANDIDATE_PORTAL_LOGIN_URL } from "@/lib/candidatePortal";
 import { getBoard } from "@/lib/jobs-facets";
 import { jobCardImage, type PublicJob } from "@/lib/jobs-fetch";
 
@@ -29,8 +30,6 @@ import { jobCardImage, type PublicJob } from "@/lib/jobs-fetch";
  */
 
 type Lang = "en" | "no";
-
-const ATS_BASE = process.env.NEXT_PUBLIC_ATS_URL?.replace(/\/$/, "") || "https://ats.arbeidmatch.no";
 
 /**
  * The town chips lead to the town's own page, not to a query string the list
@@ -114,9 +113,14 @@ export async function Forsiden({ lang = "en" }: { lang?: Lang }) {
       <JobPostingJsonLd jobs={jobs} />
       <ForsidenFaqJsonLd />
 
-      {/* The two doors and the language, on one line. The site keeps no
-          accounts: Log in is the ATS's candidate login, and a company enters
-          through Register company or through its own workspace link. */}
+      {/* The two doors and the language, on one line. Log in is the employee
+          portal on the board - the same door the navbar, the drawer and
+          /employees use - and a company enters through Post a job or through
+          its own workspace link.
+
+          It pointed at the ATS candidate login when this front page was
+          written, which is the back office and not the place a man signs in to
+          see his own file; every login on the site reads one constant now. */}
       <div className="flex flex-wrap items-center justify-end gap-3 border-b border-border px-6 py-3">
         <div className="inline-flex overflow-hidden rounded border border-border text-[11px] font-semibold">
           <span className="bg-gold/15 px-3 py-1.5 text-gold">{lang === "en" ? "EN" : "NO"}</span>
@@ -125,7 +129,7 @@ export async function Forsiden({ lang = "en" }: { lang?: Lang }) {
           </a>
         </div>
         <a
-          href={`${ATS_BASE}/candidate/login`}
+          href={CANDIDATE_PORTAL_LOGIN_URL}
           className="rounded border border-border px-4 py-2 text-sm font-semibold text-navy transition hover:border-gold"
         >
           {lang === "en" ? "Log in" : "Logg inn"}

--- a/src/components/home/ForsidenDoors.tsx
+++ b/src/components/home/ForsidenDoors.tsx
@@ -2,19 +2,24 @@
 
 import Link from "next/link";
 
+import { CANDIDATE_PORTAL_SIGNUP_URL } from "@/lib/candidatePortal";
+
 /**
  * The two doors, and where each one lands.
  *
- * This site keeps no accounts. The login is the ATS's, and this page sends
- * people there with the right context: one user base, one password to reset,
- * and no second list of companies to fall out of step with the first.
+ * This site keeps no accounts of its own. The candidate's account lives on the
+ * board, and the two constants in lib/candidatePortal are the only place that
+ * is written down, so a door here cannot fall out of step with the navbar, the
+ * drawer or /employees.
+ *
+ * Create profile used to open the ATS candidate login. That is the wrong door
+ * twice over: the ATS is the back office, and a man who has no profile yet
+ * needs the place where one is made, not a password box.
  *
  * It is a client component because pressing a service is also what tells the
  * leaving panel which conversation the visitor was in - somebody reading about
  * staffing should not be offered a job alert on the way out.
  */
-
-const ATS_BASE = process.env.NEXT_PUBLIC_ATS_URL?.replace(/\/$/, "") || "https://ats.arbeidmatch.no";
 
 function rememberService(service: "recruitment" | "staffing" | "job_ad") {
   try {
@@ -39,12 +44,12 @@ export function ForsidenDoors() {
           <li>You can see who has read it</li>
           <li>You delete it whenever you want</li>
         </ul>
-        <a
-          href={`${ATS_BASE}/candidate/login`}
+        <Link
+          href={CANDIDATE_PORTAL_SIGNUP_URL}
           className="mt-6 inline-flex items-center rounded bg-gold px-6 py-3 text-sm font-bold text-navy transition hover:bg-gold-hover"
         >
           Create profile
-        </a>
+        </Link>
       </div>
 
       {/* The company that needs people. Three ways, and the choice decides what opens. */}

--- a/src/lib/candidatePortal.test.ts
+++ b/src/lib/candidatePortal.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { CANDIDATE_PORTAL_LOGIN_URL, CANDIDATE_PORTAL_SIGNUP_URL } from "./candidatePortal";
+
+/**
+ * A candidate who cannot sign in has no way of telling us so, and the last time
+ * this broke it broke silently: the correction of 6 August put every login on
+ * jobs.arbeidmatch.no, and the front page rewritten on 2 September brought back
+ * `ats.arbeidmatch.no/candidate/login` in two places - the top bar and the
+ * Create profile door. Both are the back office, where a candidate's password
+ * does not exist.
+ *
+ * So the rule is written down rather than remembered: nothing the visitor can
+ * press may address the ATS candidate area directly. If a new door needs one of
+ * these, it reads the constant.
+ */
+
+const SRC = join(process.cwd(), "src");
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...sourceFiles(full));
+    } else if (/\.(ts|tsx)$/.test(entry) && !entry.endsWith(".test.ts") && !entry.endsWith(".test.tsx")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe("candidate portal doors", () => {
+  it("keeps the login on the board, not in the ATS", () => {
+    expect(CANDIDATE_PORTAL_LOGIN_URL).toBe("https://jobs.arbeidmatch.no/login");
+  });
+
+  it("sends a candidate without a profile somewhere a profile can be made", () => {
+    expect(CANDIDATE_PORTAL_SIGNUP_URL).not.toMatch(/login/);
+  });
+
+  it("has no page pointing a candidate at the ATS login", () => {
+    const offenders = sourceFiles(SRC).filter((file) => /candidate\/login/.test(readFileSync(file, "utf8")));
+    expect(offenders).toEqual([]);
+  });
+});

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,7 +7,10 @@ const config: Config = {
       colors: {
         navy: "#0D1B2A",
         gold: "#C9A84C",
-        "gold-hover": "#B8913A",
+        // The pressed gold twenty-three files write by hand as #B8953F. The
+        // token said #B8913A, so two buttons side by side went to two
+        // different golds under a finger; the token follows the buttons.
+        "gold-hover": "#B8953F",
         surface: "#F5F6F8",
         "text-secondary": "#555555",
         border: "#E2E5EA",


### PR DESCRIPTION
Two things a candidate meets on a phone. Verified on an iPhone 13 viewport (390×844) with `userType=candidate`.

## Log in — a regression, not a new bug

The correction of 6 August (`1d01645`) put every login on `jobs.arbeidmatch.no/login` and said why: the ATS is the door for our own staff, not for a man who wants to see his own file. The front page rewritten on 2 September (`0934de2`) brought the ATS login back in two places:

- `Forsiden.tsx` — the top-bar **Log in**, which on a phone is the only one visible without opening the hamburger, went to `ats.arbeidmatch.no/candidate/login`.
- `ForsidenDoors.tsx` — **Create profile** went to that same login page, which is wrong twice over: the back office, and a password box for a man who has no profile yet.

The navbar, the drawer, `/employees` and `CandidateAccountSection` were already reading `lib/candidatePortal`. Now these two do as well, and `src/lib/candidatePortal.test.ts` walks `src/` so the next front page cannot quietly undo it again. Confirmed the guard bites: putting the old URL back fails the test.

Create profile now opens `CANDIDATE_PORTAL_SIGNUP_URL` (`/candidate-request`), the place a profile is actually made.

## Colours — measured, not impressions

Sampling the background down `/for-candidates` on mobile, before:

| px | colour |
|---|---|
| 61–401 | `#0d1b2a` |
| 402–729 | `#0a121c` |
| 729–994 | `#09111b` (a card shadow bleeding to the edge) |
| 1008–1788 | `#0d1b2a` |
| 1788–3649 | `#eef1f5` |
| 3650–5054 | `#0a121c` |

Three navies within four per cent of each other. On a wide screen they read as sections; on a phone, where every section is the full width and they meet edge to edge, they read as seams — the page looks like it failed to paint rather than like it changed subject.

One navy now, one light surface (`#F5F6F8`, the `surface` token, not `#eef1f5`), and the cards lift off it with the translucent white `/employees` and `/premium` already use instead of repeating the section's own colour behind a border. After the change the page renders exactly two backgrounds: `rgb(13, 27, 42)` and `rgb(245, 246, 248)`.

The gold under a finger was two colours as well: the token said `#B8913A` while twenty-three files wrote `#B8953F` by hand, so two buttons side by side went to two different golds when pressed. The token follows the files.

## Checks

- `npx vitest run` — 103/103 pass, including the three new ones.
- `npx tsc --noEmit` — clean.
- `npm run lint` — 57 problems, 16 errors: identical to the pre-existing baseline on `main`, none added.
- Re-shot the candidate flow on the iPhone 13 viewport and confirmed the link targets in the rendered DOM: `Log in → https://jobs.arbeidmatch.no/login`, `Create profile → /candidate-request`.

The two portal hosts are unreachable from the environment this was built in (the egress proxy answers 403 to `jobs.arbeidmatch.no` and `ats.arbeidmatch.no`), so the sign-in itself was not exercised end to end. If a candidate still cannot get in at `jobs.arbeidmatch.no/login` after this deploys, the account lives on the board and the answer is there, not in this repository.

## Seen but deliberately left alone

Design decisions rather than defects, listed so they are not lost:

- The front page carries two themes. On mobile: navy navbar, a white strip (EN/NO, Log in, Post a job), navy hero, ~2600px of white, ~3000px of navy. The new job-board front page was mounted on top of the older dark marketing page. This is the largest remaining incoherence, and fixing it means choosing one theme for the front page.
- The mobile drawer ignores the audience: with `userType=candidate` it still shows "For Employers" and a gold "Request candidates" button.
- `#B8860B` (a different gold from the brand) appears 42 times, and `#0f1923` — a second dark base, mostly on `/premium` — 131 times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWyMo7EsaXY6NxJ1oqqboY

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWyMo7EsaXY6NxJ1oqqboY)_