### PR TITLE
The candidate portal is in the ATS, and every login on the site said otherwise

### DIFF
--- a/src/components/home/Forsiden.tsx
+++ b/src/components/home/Forsiden.tsx
@@ -113,14 +113,13 @@ export async function Forsiden({ lang = "en" }: { lang?: Lang }) {
       <JobPostingJsonLd jobs={jobs} />
       <ForsidenFaqJsonLd />
 
-      {/* The two doors and the language, on one line. Log in is the employee
-          portal on the board - the same door the navbar, the drawer and
-          /employees use - and a company enters through Post a job or through
+      {/* The two doors and the language, on one line. Log in is the candidate
+          portal in the ATS, and a company enters through Post a job or through
           its own workspace link.
 
-          It pointed at the ATS candidate login when this front page was
-          written, which is the back office and not the place a man signs in to
-          see his own file; every login on the site reads one constant now. */}
+          This page had the destination right by hand and every other login on
+          the site had it wrong. All of them read one constant now, and it is
+          the constant that moved - see lib/candidatePortal. */}
       <div className="flex flex-wrap items-center justify-end gap-3 border-b border-border px-6 py-3">
         <div className="inline-flex overflow-hidden rounded border border-border text-[11px] font-semibold">
           <span className="bg-gold/15 px-3 py-1.5 text-gold">{lang === "en" ? "EN" : "NO"}</span>

--- a/src/components/home/ForsidenDoors.tsx
+++ b/src/components/home/ForsidenDoors.tsx
@@ -7,14 +7,13 @@ import { CANDIDATE_PORTAL_SIGNUP_URL } from "@/lib/candidatePortal";
 /**
  * The two doors, and where each one lands.
  *
- * This site keeps no accounts of its own. The candidate's account lives on the
- * board, and the two constants in lib/candidatePortal are the only place that
- * is written down, so a door here cannot fall out of step with the navbar, the
- * drawer or /employees.
+ * This site keeps no accounts of its own. The candidate's account lives in the
+ * ATS, and the two constants in lib/candidatePortal are the only place either
+ * address is written down, so a door here cannot fall out of step with the
+ * navbar, the drawer or /employees.
  *
- * Create profile used to open the ATS candidate login. That is the wrong door
- * twice over: the ATS is the back office, and a man who has no profile yet
- * needs the place where one is made, not a password box.
+ * Create profile opened the candidate login. Right host, wrong page: a man who
+ * has no profile yet needs the place where one is made, not a password box.
  *
  * It is a client component because pressing a service is also what tells the
  * leaving panel which conversation the visitor was in - somebody reading about

--- a/src/lib/candidatePortal.test.ts
+++ b/src/lib/candidatePortal.test.ts
@@ -6,16 +6,19 @@ import { describe, expect, it } from "vitest";
 import { CANDIDATE_PORTAL_LOGIN_URL, CANDIDATE_PORTAL_SIGNUP_URL } from "./candidatePortal";
 
 /**
- * A candidate who cannot sign in has no way of telling us so, and the last time
- * this broke it broke silently: the correction of 6 August put every login on
- * jobs.arbeidmatch.no, and the front page rewritten on 2 September brought back
- * `ats.arbeidmatch.no/candidate/login` in two places - the top bar and the
- * Create profile door. Both are the back office, where a candidate's password
- * does not exist.
+ * A candidate who cannot sign in has no way of telling us so, and this one broke
+ * twice in one direction and once in the other:
  *
- * So the rule is written down rather than remembered: nothing the visitor can
- * press may address the ATS candidate area directly. If a new door needs one of
- * these, it reads the constant.
+ * - From 6 August this constant read `jobs.arbeidmatch.no/login`. That host is the
+ *   external board the ATS mirrors, not a system of ours, so the navbar, the mobile
+ *   drawer, /employees and the candidate account panel all sent people to a
+ *   stranger's login page.
+ * - The front page written on 2 September used the right destination by hand,
+ *   and on 4 September it was "corrected" onto the wrong constant, which took the
+ *   last working door away.
+ *
+ * So the destination is asserted here rather than remembered, and the rule is that
+ * every visible login reads the constant instead of writing a host of its own.
  */
 
 const SRC = join(process.cwd(), "src");
@@ -34,16 +37,29 @@ function sourceFiles(dir: string): string[] {
 }
 
 describe("candidate portal doors", () => {
-  it("keeps the login on the board, not in the ATS", () => {
-    expect(CANDIDATE_PORTAL_LOGIN_URL).toBe("https://jobs.arbeidmatch.no/login");
+  it("points the login at the ATS candidate portal", () => {
+    expect(CANDIDATE_PORTAL_LOGIN_URL).toBe("https://ats.arbeidmatch.no/candidate/login");
+  });
+
+  it("never points a candidate at the external board's login", () => {
+    expect(CANDIDATE_PORTAL_LOGIN_URL).not.toMatch(/jobs\.arbeidmatch\.no/);
+  });
+
+  it("never points a candidate at the staff login", () => {
+    // ats.arbeidmatch.no/login is our own staff door, with 2FA behind it.
+    expect(CANDIDATE_PORTAL_LOGIN_URL).not.toMatch(/^https:\/\/ats\.arbeidmatch\.no\/login\b/);
   });
 
   it("sends a candidate without a profile somewhere a profile can be made", () => {
     expect(CANDIDATE_PORTAL_SIGNUP_URL).not.toMatch(/login/);
   });
 
-  it("has no page pointing a candidate at the ATS login", () => {
-    const offenders = sourceFiles(SRC).filter((file) => /candidate\/login/.test(readFileSync(file, "utf8")));
+  it("has no page writing a login host of its own", () => {
+    const offenders = sourceFiles(SRC).filter((file) => {
+      const text = readFileSync(file, "utf8");
+      if (file.endsWith(join("lib", "candidatePortal.ts"))) return false;
+      return /(jobs|ats)\.arbeidmatch\.no\/(candidate\/)?login/.test(text);
+    });
     expect(offenders).toEqual([]);
   });
 });

--- a/src/lib/candidatePortal.ts
+++ b/src/lib/candidatePortal.ts
@@ -1,14 +1,27 @@
 /**
- * Jobs portal candidate auth URLs. Use only in `href`, `router.push`, or server redirects —
+ * Candidate auth URLs. Use only in `href`, `router.push`, or server redirects —
  * never render these values as visible page copy.
  */
 /**
- * HIS CORRECTION, 6 August 2026: the employee portal is on jobs.arbeidmatch.no/login.
+ * HIS CORRECTION, 4 September 2026: "nu este pe website ci pe ats".
  *
- * It had pointed at the ATS login since this constant was written, which is the door
- * for our own staff and not for a man who wants to see his own file. While
- * applications and employment live on the board, that is where an employee signs in,
- * and every "Employee portal" link on this site reads this one value.
+ * The candidate portal is the ATS's. `ats.arbeidmatch.no/candidate/login` is a real
+ * page of ours — Candidate registration, email and password, magic link, Google,
+ * forgot password — and behind it sit the dashboard, applications, profile,
+ * timesheets and availability the candidate signs in to reach.
+ *
+ * `jobs.arbeidmatch.no` IS NOT OURS. It is the external board we mirror: the ATS
+ * scrapes it, `BOARD_SOURCE` names it, `board-mirror-link` treats it as a foreign
+ * host. Nobody's password lives there. This constant said
+ * `jobs.arbeidmatch.no/login` from 6 August until today, so every "Employee portal"
+ * and "Sign in to your profile" link on this site — navbar, mobile drawer,
+ * /employees, the candidate account panel — sent a candidate to a stranger's login
+ * page, which is exactly what he reported: on a phone he could not sign in at all.
+ *
+ * Do not point this at the board again, and do not point it at
+ * `ats.arbeidmatch.no/login` either: that one is the staff door, with 2FA.
  */
-export const CANDIDATE_PORTAL_LOGIN_URL = "https://jobs.arbeidmatch.no/login" as const;
+export const CANDIDATE_PORTAL_LOGIN_URL = "https://ats.arbeidmatch.no/candidate/login" as const;
+
+/** Where a candidate with no profile yet goes. The ATS points at this same page. */
 export const CANDIDATE_PORTAL_SIGNUP_URL = "/candidate-request" as const;


### PR DESCRIPTION
**Corrects PR #12, which had the login backwards.** Merge this promptly: production currently carries the wrong destination.

His correction of 4 September: *"nu este pe website ci pe ats"*. Checked against `Arbeidmatch/ats`, and he is right on both counts.

## What the ATS repository shows

`ats.arbeidmatch.no/candidate/login` is a real page of ours — `src/app/candidate/(public)/login/page.tsx`: "Candidate registration", email and password sign-in, create account, magic link, Google, forgot password, landing on `/candidate/dashboard`. Behind it sit `candidate/(app)/` dashboard, applications, profile, timesheets, availability, referrals.

`jobs.arbeidmatch.no` **is not ours**. It is the external board the ATS mirrors:

- `src/lib/social-bot/board-source.ts` — `BOARD_SOURCE = "jobs.arbeidmatch.no"`, the value marking a row as *mirrored from the public board*.
- `src/lib/board-mirror-link.ts` — `BOARD_HOSTS`, treated as a foreign host.
- `src/lib/outbound/link-check.ts` — "the board does not serve slugs"; "jobs.arbeidmatch.no answers a missing job with HTTP 200 and a page that says 404".

No password of ours lives there.

## What was actually broken

`CANDIDATE_PORTAL_LOGIN_URL` has read `jobs.arbeidmatch.no/login` since 6 August. Every link reading it went to a stranger's login page:

- the navbar
- the mobile drawer ("Employee portal")
- `/employees`
- `CandidateAccountSection` ("Sign in to your profile")

That is the reported symptom: on a phone there was no working door at all. The one place that had it right was the front page top bar, which wrote `ats.arbeidmatch.no/candidate/login` by hand — and PR #12 "corrected" that onto the wrong constant, removing the last working door. It was live for roughly four minutes.

## The change

The constant now points at the ATS candidate login, which repairs all five doors at once. `src/lib/candidatePortal.test.ts` asserts the destination instead of trusting a comment, and also refuses `ats.arbeidmatch.no/login` — that one is the staff door, with 2FA behind it.

Create profile keeps pointing at `/candidate-request`; the ATS's own `api/go/apply/route.ts` names `https://arbeidmatch.no/candidate-request` as the register page, so that half of #12 was right.

The colour work from #12 is untouched and stays.

## One thing worth your decision

Commit `a6ea9f5` records *"eu nu vreau sa expun ats ul ci websiteul vreau sa fie public"*. That was about job advert URLs, and this is a login rather than public content, so I have treated it as out of scope — but it does put `ats.arbeidmatch.no` in front of visitors again. If you would rather the login sat behind a path on `arbeidmatch.no`, say so and it becomes a redirect instead of a link.

## Checks

- `npx vitest run` — 105/105 pass.
- `npx tsc --noEmit` — clean.
- `npm run lint` — 57 problems, 16 errors: the pre-existing baseline, none added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWyMo7EsaXY6NxJ1oqqboY

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWyMo7EsaXY6NxJ1oqqboY)_